### PR TITLE
Add plugin-promise and use recommended conf

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 module.exports = {
-  extends: 'xo-space/esnext',
+  plugins: ['promise'],
+  extends: ['xo-space/esnext', 'plugin:promise/recommended'],
   rules: {
     'capitalized-comments': 'off',
     camelcase: 'warn',

--- a/package.json
+++ b/package.json
@@ -47,11 +47,12 @@
     "sindre"
   ],
   "dependencies": {
-    "eslint-config-xo-space": "^0.18.0"
+    "eslint-config-xo-space": "^0.18.0",
+    "eslint-plugin-promise": "^3.7.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",
-    "eslint": "^4.17.0",
+    "eslint": "^4.18.2",
     "is-plain-obj": "^1.0.0",
     "temp-write": "^3.4.0"
   },


### PR DESCRIPTION
Add plugin/rule for promise

https://github.com/xjamundx/eslint-plugin-promise#rules

| rule                                                     | description                                                                      | recommended | fixable  |
| -------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------- | -------- |
| `catch-or-return`                     | Enforces the use of `catch()` on un-returned promises.                           | :bangbang:  |          |
| `no-return-wrap`                       | Avoid wrapping values in `Promise.resolve` or `Promise.reject` when not needed.  | :bangbang:  |          |
| `param-names`                           | Enforce consistent param names when creating new promises.                       | :bangbang:  | :wrench: |
| `always-return`                         | Return inside each `then()` to create readable and reusable Promise chains.      | :bangbang:  |          |
| `no-native`                             | In an ES5 environment, make sure to create a `Promise` constructor before using. |             |          |
| `no-nesting`                            | Avoid nested `then()` or `catch()` statements                                    | :warning:   |          |
| `no-promise-in-callback`       | Avoid using promises inside of callbacks                                         | :warning:   |          |
| `no-callback-in-promise`       | Avoid calling `cb()` inside of a `then()` (use [nodeify][] instead)              | :warning:   |          |
| `avoid-new`                                | Avoid creating `new` promises outside of utility libs (use [pify][] instead)     | :warning:   |          |
| `no-new-statics`                   | Avoid calling `new` on a Promise static method                                   | :bangbang:  |          |
| `no-return-in-finally`           | Disallow return statements in `finally()`                                        | :warning:   |          |
| `valid-params`                         | Ensures the proper number of arguments are passed to Promise functions           | :warning:   |          |
| `prefer-await-to-then`           | Prefer `await` to `then()` for reading Promise values                            | :seven:     |          |
| `prefer-await-to-callbacks` | Prefer async/await to the callback pattern                                       | :seven:     |          |