### PR TITLE
Use ESLint 5.0.0 and directly eslint-config-xo

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@
 
 module.exports = {
   plugins: ['promise'],
-  extends: ['xo-space/esnext', 'plugin:promise/recommended'],
+  extends: ['xo/esnext', 'plugin:promise/recommended'],
   rules: {
+    indent: [2, 2, {SwitchCase: 1}],
     'capitalized-comments': 'off',
     camelcase: 'warn',
     'no-console': 'error',

--- a/package.json
+++ b/package.json
@@ -47,17 +47,17 @@
     "sindre"
   ],
   "dependencies": {
-    "eslint-config-xo-space": "^0.18.0",
+    "eslint-config-xo": "^0.23.0",
     "eslint-plugin-promise": "^3.7.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",
-    "eslint": "^4.18.2",
+    "eslint": "^5.0.0",
     "is-plain-obj": "^1.0.0",
     "temp-write": "^3.4.0"
   },
   "peerDependencies": {
-    "eslint": ">=4.6.0"
+    "eslint": ">=5.0.0"
   },
   "eslintConfig": {
     "extends": "xo-space/esnext",


### PR DESCRIPTION
Bump to ESLint 5.0.0 and use directly https://github.com/xojs/eslint-config-xo due to 
https://github.com/xojs/eslint-config-xo-space is not really maintained. 