### PR TITLE
✨ disable eslint rules handled by prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,13 @@ module.exports = {
       }
     ],
     'prefer-promise-reject-errors': 'warn',
-
-    'promise/no-return-wrap': 'off'
+    
+    'promise/no-return-wrap': 'off',
+    
+    // disable rules in prettier scope
+    '@typescript-eslint/object-curly-spacing': 'off',
+    '@typescript-eslint/quotes': 'off',
+    'no-mixed-operators': 'off',
+    'operator-linebreak': 'off',
   }
 };


### PR DESCRIPTION
since we made the decision to use prettier in our projects, we need to disable eslint rules that conflicts with the default prettier configuration