### PR TITLE
feat: add exception pattern for typebox

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,15 @@ module.exports = {
             },
           },
         ],
+        'new-cap': [
+          'error',
+          {
+            newIsCap: true,
+            capIsNew: true,
+            // Override for typebox usage
+            capIsNewExceptionPattern: '^Type\\..',
+          },
+        ],
       },
     },
     {


### PR DESCRIPTION
Override pour permettre d'utiliser typebox.

```
import {Type} from '@sinclair/typebox';
export const schema = Type.Object({...});
```