### PR TITLE
fix: remove eslint-plugin-package-json to get rid of the npm audit error

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,6 @@ ruleNamingConventionOverride[1].format = [
 module.exports = {
   overrides: [
     {
-      files: ['package.json'],
-      plugins: ['package-json'],
-      extends: ['plugin:package-json/recommended'],
-      parser: 'jsonc-eslint-parser',
-    },
-    {
       files: ['*.{js,ts}'],
       plugins: ['import', 'promise'],
       extends: ['xo', 'plugin:promise/recommended'],

--- a/package.json
+++ b/package.json
@@ -49,15 +49,13 @@
   "dependencies": {
     "@typescript-eslint/parser": "^7.0.2",
     "eslint-config-xo": "^0.44.0",
-    "eslint-config-xo-typescript": "^4.0.0",
-    "jsonc-eslint-parser": "^2.4.0"
+    "eslint-config-xo-typescript": "^4.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "ava": "^6.1.2",
     "eslint": "^8.52.0",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-package-json": "^0.10.4",
     "eslint-plugin-promise": "^6.1.1",
     "typescript": "^5.3.3"
   },
@@ -65,7 +63,6 @@
     "@typescript-eslint/eslint-plugin": ">=7.0.2",
     "eslint": ">=8.0.0",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-package-json": "^0.10.4",
     "eslint-plugin-promise": "^6.1.1",
     "typescript": ">=5.0.0"
   },


### PR DESCRIPTION
npm audit :

![image](https://github.com/radiofrance/eslint-config-radiofrance/assets/1228204/149425b4-ba1f-4aee-b8a9-3d753478c71f)
