### PR TITLE
fix: prevent breaking changes in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">=7.0.2",
-    "eslint": ">=8.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.2",
+    "eslint": "^8.0.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-promise": "^6.1.1",
-    "typescript": ">=5.0.0"
+    "typescript": "^5.0.0"
   },
   "eslintConfig": {
     "extends": "./index.js"


### PR DESCRIPTION
@typescript-eslint/eslint-plugin@latest is now v8, which is not compatible

this merge request prevent installing the non compatible version