### PR TITLE
chore: Add nodejs 22 to the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 22
           - 20
           - 18
     steps:


### PR DESCRIPTION
nodejs 22 is out, and in a few month will be LTS