### PR TITLE
fix: findRule now returns the last occurence, when multiple are found

### DIFF
--- a/source/utils.js
+++ b/source/utils.js
@@ -25,7 +25,7 @@ export function allowSnakeCase(configList) {
  * @param {string} ruleName
  */
 export function findRule(configList, ruleName) {
-  const rule = configList.find(config => config.rules?.[ruleName])?.rules?.[ruleName];
+  const rule = configList.findLast(config => config.rules?.[ruleName])?.rules?.[ruleName];
   assert(rule);
   return rule;
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,27 @@
+import test from 'ava';
+import {findRule} from '../source/utils.js';
+/** @import { Linter } from 'eslint' */
+
+test('Finds the rule by it\'s name', t => {
+  /** @type {Linter.Config[]} */
+  const config = [
+    {rules: {rule1: ['off', 'rule1']}},
+    {rules: {rule2: ['error', 'rule2']}},
+    {rules: {rule3: ['error', 'rule3']}},
+  ];
+
+  const rule = findRule(config, 'rule2');
+  t.deepEqual(rule, ['error', 'rule2']);
+});
+
+test('Finds the last occurence of a rule', t => {
+  /** @type {Linter.Config[]} */
+  const config = [
+    {rules: {rule1: ['off', 'rule1']}},
+    {rules: {rule2: ['error', 'rule2']}},
+    {rules: {rule1: ['error', 'rule1']}},
+  ];
+
+  const rule = findRule(config, 'rule1');
+  t.deepEqual(rule, ['error', 'rule1']);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "noEmit": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2022",
+    "target": "es2024",
   },
   "include": [
     "*.js",


### PR DESCRIPTION
because eslint uses the last one, not the first