### PR TITLE
feat: improve typebox compatibility

### DIFF
--- a/source/config.js
+++ b/source/config.js
@@ -53,7 +53,7 @@ export default [
       'new-cap': ['error', {
         newIsCap: true,
         capIsNew: true,
-        capIsNewExceptionPattern: '^Type\\..',
+        capIsNewExceptionPattern: '^(?:Value|Type|TypeCompiler)\\..',
       }],
 
       '@stylistic/indent': ['error', 2, {SwitchCase: 1}], // copied from eslint-config-xo-typescript/space


### PR DESCRIPTION
Typebox is not exporting only `Type`, it also exports `Value` and `TypeCompiler`