### PR TITLE
feat: add overrides for typescript-eslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
   },
   "peerDependencies": {
     "eslint": "^9.19.0"
+  },
+  "overrides": {
+    "typescript-eslint": "8.30.1"
   }
 }


### PR DESCRIPTION
Due to bug in https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.31.0