### PR TITLE
feat: require .ts and forbid .js extension in TypeScript relative imports

### DIFF
--- a/source/config.js
+++ b/source/config.js
@@ -56,6 +56,8 @@ const config = [
   {
     files: [tsSelector],
     rules: {
+      // Force the `.ts` extension and forbid `.js` in relative imports.
+      'import-x/extensions': ['error', 'ignorePackages', {js: 'never', ts: 'always'}],
       // Use type instead of interface as per global instructions.
       '@typescript-eslint/consistent-type-definitions': ['warn', 'type'],
       // Disable theses no-unsafe rules to allow more flexibility.

--- a/test/lint-ts.js
+++ b/test/lint-ts.js
@@ -22,3 +22,8 @@ test('throw error no-inferrable-types', async t => {
   const errors = await runEslint('const foo: number = 5;\n', filePath);
   assertError(t, errors, ['@typescript-eslint/no-inferrable-types']);
 });
+
+test('throw error import-x/extensions on a .js relative import', async t => {
+  const errors = await runEslint('import foo from \'./bar.js\';\n\nif (foo) {\n  // not empty\n}\n', filePath);
+  assertError(t, errors, ['import-x/extensions']);
+});


### PR DESCRIPTION
In TS projects the source files are resolved at the literal path (Node type-strip) and imports are written with .ts specifiers (rewriteRelativeImportExtensions). 

A .js relative import therefore breaks at runtime, but 'import-x/extensions' with only 'ignorePackages' just checks that *an* extension is present, not which one, so it slips through.

Scope the stricter {js: 'never', ts: 'always'} option to the TS-only block so JavaScript consumers keep their required .js extensions.