### PR TITLE
test: migrate from ava to vitest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+coverage/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build-check": "tsc --noEmit",
     "lint": "eslint",
-    "test": "ava"
+    "test": "vitest run --config test/vitest.config.js"
   },
   "files": [
     "source"
@@ -56,8 +56,9 @@
   },
   "devDependencies": {
     "@types/node": "^24.7.0",
-    "ava": "^6.1.2",
-    "typescript": "^5.9.3"
+    "@vitest/coverage-v8": "^4.1.9",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.9"
   },
   "peerDependencies": {
     "eslint": ">=10.1.0"

--- a/test/helper/utils.js
+++ b/test/helper/utils.js
@@ -1,17 +1,15 @@
 import {ESLint} from 'eslint';
+import {expect} from 'vitest';
 import eslintConfigRadiofrance from '../../source/config.js';
-/** @import {ExecutionContext} from 'ava' */
 /** @import {Linter} from 'eslint' */
 
 /**
- * @param {ExecutionContext} t
  * @param {Linter.LintMessage[]} errors
  * @param {string[]} ruleIds
  */
-export function assertError(t, errors, ruleIds) {
-  const message = JSON.stringify(errors);
-  t.like(errors, ruleIds.map(ruleId => ({ruleId})), message);
-  t.is(errors.length, ruleIds.length, message);
+export function assertError(errors, ruleIds) {
+  expect(errors).toMatchObject(ruleIds.map(ruleId => ({ruleId})));
+  expect(errors).toHaveLength(ruleIds.length);
 }
 
 /**

--- a/test/lint-js.test.js
+++ b/test/lint-js.test.js
@@ -1,19 +1,19 @@
-import test from 'ava';
+import {expect, test} from 'vitest';
 import {assertError, runEslint} from './helper/utils.js';
 
 const filePath = 'test/helper/js-placeholder.js';
 
-test('success', async t => {
+test('success', async () => {
   const errors = await runEslint('const x = true;\n\nif (x) {\n  // Not empty\n}\n', filePath);
-  t.deepEqual(errors, []);
+  expect(errors).toEqual([]);
 });
 
-test('throw error no-console', async t => {
+test('throw error no-console', async () => {
   const errors = await runEslint('const x = true;\n\nif (x) {\n  console.log();\n}\n', filePath);
-  assertError(t, errors, ['no-console']);
+  assertError(errors, ['no-console']);
 });
 
-test('throw error camelcase', async t => {
+test('throw error camelcase', async () => {
   const errors = await runEslint('const not_in_camelcase = true;\n\nif (not_in_camelcase) {\n  // not empty\n}\n', filePath);
-  assertError(t, errors, ['camelcase', 'camelcase']);
+  assertError(errors, ['camelcase', 'camelcase']);
 });

--- a/test/lint-ts.test.js
+++ b/test/lint-ts.test.js
@@ -1,29 +1,29 @@
-import test from 'ava';
+import {expect, test} from 'vitest';
 import {assertError, runEslint} from './helper/utils.js';
 
 const filePath = 'test/helper/ts-placeholder.ts';
 
-test('success', async t => {
+test('success', async () => {
   const errors = await runEslint('type OneType = string; const t: OneType = \'randomString\';\n', filePath);
-  t.deepEqual(errors, []);
+  expect(errors).toEqual([]);
 });
 
-test('throw error no-console', async t => {
+test('throw error no-console', async () => {
   const errors = await runEslint('const x = true;\n\nif (x) {\n  console.log();\n}\n', filePath);
-  assertError(t, errors, ['no-console']);
+  assertError(errors, ['no-console']);
 });
 
-test('throw error naming-convention', async t => {
+test('throw error naming-convention', async () => {
   const errors = await runEslint('const not_in_camelcase = true;\n\nif (not_in_camelcase) {\n  // not empty\n}\n', filePath);
-  assertError(t, errors, ['@typescript-eslint/naming-convention']);
+  assertError(errors, ['@typescript-eslint/naming-convention']);
 });
 
-test('throw error no-inferrable-types', async t => {
+test('throw error no-inferrable-types', async () => {
   const errors = await runEslint('const foo: number = 5;\n', filePath);
-  assertError(t, errors, ['@typescript-eslint/no-inferrable-types']);
+  assertError(errors, ['@typescript-eslint/no-inferrable-types']);
 });
 
-test('throw error import-x/extensions on a .js relative import', async t => {
+test('throw error import-x/extensions on a .js relative import', async () => {
   const errors = await runEslint('import foo from \'./bar.js\';\n\nif (foo) {\n  // not empty\n}\n', filePath);
-  assertError(t, errors, ['import-x/extensions']);
+  assertError(errors, ['import-x/extensions']);
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,8 +1,8 @@
-import test from 'ava';
+import {expect, test} from 'vitest';
 import {findRule} from '../source/utils.js';
 /** @import { Linter } from 'eslint' */
 
-test('Finds the rule by it\'s name', t => {
+test('Finds the rule by it\'s name', () => {
   /** @type {Linter.Config[]} */
   const config = [
     {rules: {rule1: ['off', 'rule1']}},
@@ -11,10 +11,10 @@ test('Finds the rule by it\'s name', t => {
   ];
 
   const rule = findRule(config, 'rule2');
-  t.deepEqual(rule, ['error', 'rule2']);
+  expect(rule).toEqual(['error', 'rule2']);
 });
 
-test('Finds the first occurence of a rule', t => {
+test('Finds the first occurence of a rule', () => {
   /** @type {Linter.Config[]} */
   const config = [
     {rules: {rule1: ['off', 'rule1']}},
@@ -23,5 +23,5 @@ test('Finds the first occurence of a rule', t => {
   ];
 
   const rule = findRule(config, 'rule1');
-  t.deepEqual(rule, ['off', 'rule1']);
+  expect(rule).toEqual(['off', 'rule1']);
 });

--- a/test/vitest.config.js
+++ b/test/vitest.config.js
@@ -11,6 +11,6 @@ export default defineConfig({
       reporter: ['text-summary', 'html', 'cobertura', 'lcov'],
     },
     restoreMocks: true,
-    testTimeout: inspector.url() ? 0 : undefined,
+    testTimeout: inspector.url() ? 0 : 30_000,
   },
 });

--- a/test/vitest.config.js
+++ b/test/vitest.config.js
@@ -1,0 +1,16 @@
+import inspector from 'node:inspector';
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.js'],
+    coverage: {
+      enabled: true,
+      include: ['source/**/*.js'],
+      exclude: ['test/**'],
+      reporter: ['text-summary', 'html', 'cobertura', 'lcov'],
+    },
+    restoreMocks: true,
+    testTimeout: inspector.url() ? 0 : undefined,
+  },
+});


### PR DESCRIPTION
## Résumé

Migration du runner de tests d'ava vers vitest, avec une configuration alignée sur les conventions des projets murmure (`test/vitest.config.*`, script `vitest run --config ...`).

## Changements

- Remplacement de `ava` par `vitest` + `@vitest/coverage-v8` (^4.1.9)
- Fichiers de test renommés au pattern `*.test.js` (requis par vitest) :
  - `lint-js.js` → `lint-js.test.js`
  - `lint-ts.js` → `lint-ts.test.js`
  - `utils.js` → `utils.test.js`
- Migration des assertions : `t.deepEqual` → `expect().toEqual()`, `t.like`/`t.is` → `toMatchObject`/`toHaveLength`
- `test/helper/utils.js` migré vers l'API vitest (suppression du paramètre `ExecutionContext` d'ava)
- Ajout de `test/vitest.config.js` (en JS, cohérent avec le projet) : coverage v8 avec reporters `text-summary`/`html`/`cobertura`/`lcov`, `restoreMocks`, `testTimeout` lié à l'inspector
- Script `test` mis à jour
- Ajout de `coverage/` au `.gitignore`

## Vérifications

- `npm test` : 3 fichiers, 10 tests passent
- `npm run build-check` (tsc) : OK
- `npm run lint` : OK