### PR TITLE
feat(config): add Prettier, Markdown and JSON linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,17 @@
 
 > ESLint [shareable config](https://eslint.org/docs/latest/extend/shareable-configs.html) extend from [eslint-config-xo](https://github.com/xojs/eslint-config-xo)
 
+## Features
+
+- Lint JavaScript and TypeScript files.
+- Lint JSON, JSONC and JSON5 files (`@eslint/json`).
+- Lint Markdown files in GitHub-Flavored Markdown (`@eslint/markdown`).
+- Format all code with Prettier through the `prettier/prettier` rule, so `eslint --fix` formats your files. Prettier is bundled, no extra install needed.
+
 ## Install
 
-```
-$ npm install --save-dev eslint-config-radiofrance
+```sh
+npm install --save-dev eslint-config-radiofrance
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -56,13 +56,14 @@
   ],
   "dependencies": {
     "@eslint/compat": "^2.0.5",
-    "eslint-config-xo": "^0.51.0",
-    "eslint-plugin-promise": "^7.3.0"
+    "eslint-config-xo": "^0.53.2",
+    "eslint-plugin-promise": "^7.3.0",
+    "prettier": "^3.8.4"
   },
   "devDependencies": {
     "@types/node": "^24.7.0",
     "@vitest/coverage-v8": "^4.1.9",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },
   "peerDependencies": {

--- a/source/config.js
+++ b/source/config.js
@@ -9,10 +9,10 @@ export * from './utils.js';
 const tsSelector = '**/*.{ts,cts,mts}';
 const jsSelector = '**/*.{js,cjs,mjs}';
 
-// Filter out problematic JSON configs that cause "allowTrailingCommas option is only available in JSONC" error
-// See: https://github.com/xojs/xo/issues/798
-const xoConfigs = eslintConfigXo({space: 2})
-  .filter(config => !config.language?.startsWith('json/'));
+// `prettier: true` enables the `prettier/prettier` rule (so `eslint --fix` formats)
+// and disables the conflicting `@stylistic` rules. It also brings in xo's JSON, JSONC,
+// JSON5 and Markdown (GFM) configs.
+const xoConfigs = eslintConfigXo({space: 2, prettier: true});
 
 const config = [
   includeIgnoreFile(path.resolve(process.cwd(), '.gitignore')),
@@ -32,8 +32,6 @@ const config = [
       'capitalized-comments': 'off',
       // Console should not be used in project. Instead use our internal logger.
       'no-console': 'error',
-      // Override from eslint-config-xo to avoid unnecessary newline in file.
-      '@stylistic/object-curly-newline': ['error', {consistent: true}],
       // For each require/import, we should a explicit file extension.
       'import-x/extensions': ['error', 'ignorePackages'],
       // No duplicate in import
@@ -41,11 +39,14 @@ const config = [
       // Order import by alphabet and groups ('builtin', 'external', 'internal', etc)
       'import-x/order': ['error', {alphabetize: {order: 'asc'}}],
       // Override from eslint-config-xo to allow Typebox usage.
-      'new-cap': ['error', {
-        newIsCap: true,
-        capIsNew: true,
-        capIsNewExceptionPattern: String.raw`^(?:Value|Type|TypeCompiler)\..`,
-      }],
+      'new-cap': [
+        'error',
+        {
+          newIsCap: true,
+          capIsNew: true,
+          capIsNewExceptionPattern: String.raw`^(?:Value|Type|TypeCompiler)\..`,
+        },
+      ],
     },
   },
 
@@ -53,7 +54,11 @@ const config = [
     files: [tsSelector],
     rules: {
       // Force the `.ts` extension and forbid `.js` in relative imports.
-      'import-x/extensions': ['error', 'ignorePackages', {js: 'never', ts: 'always'}],
+      'import-x/extensions': [
+        'error',
+        'ignorePackages',
+        {js: 'never', ts: 'always'},
+      ],
       // Use type instead of interface as per global instructions.
       '@typescript-eslint/consistent-type-definitions': ['warn', 'type'],
       // Disable theses no-unsafe rules to allow more flexibility.

--- a/source/utils.js
+++ b/source/utils.js
@@ -2,9 +2,10 @@ import assert from 'node:assert/strict';
 
 export function allowNullType(configList) {
   // Alter this rule to allow usage of the null type.
-  const noRestrictedTypes = /** @type {[unknown, {types: Record<string, unknown>}]} */ (
-    findRule(configList, '@typescript-eslint/no-restricted-types')
-  );
+  const noRestrictedTypes =
+    /** @type {[unknown, {types: Record<string, unknown>}]} */ (
+      findRule(configList, '@typescript-eslint/no-restricted-types')
+    );
   delete noRestrictedTypes[1].types.null;
 }
 
@@ -16,7 +17,9 @@ export function allowSnakeCase(configList) {
 }
 
 export function findRule(configList, ruleName) {
-  const rule = configList.find(config => config.rules?.[ruleName])?.rules?.[ruleName];
+  const rule = configList.find((config) => config.rules?.[ruleName])?.rules?.[
+    ruleName
+  ];
   assert.ok(rule);
   return rule;
 }

--- a/test/helper/utils.js
+++ b/test/helper/utils.js
@@ -4,17 +4,19 @@ import eslintConfigRadiofrance from '../../source/config.js';
 /** @import {Linter} from 'eslint' */
 
 /**
- * @param {Linter.LintMessage[]} errors
- * @param {string[]} ruleIds
+ Assert that the lint messages match the expected rule ids, in order and count.
+ @param {Linter.LintMessage[]} errors The lint messages returned by ESLint.
+ @param {string[]} ruleIds The expected rule ids, in the expected order.
  */
 export function assertError(errors, ruleIds) {
-  expect(errors).toMatchObject(ruleIds.map(ruleId => ({ruleId})));
+  expect(errors).toMatchObject(ruleIds.map((ruleId) => ({ruleId})));
   expect(errors).toHaveLength(ruleIds.length);
 }
 
 /**
- * @param {string} string
- * @param {string} filePath
+ Lint a string of source code through the Radio France config and return its messages.
+ @param {string} string The source code to lint.
+ @param {string} filePath The virtual file path used to pick the matching config.
  */
 export async function runEslint(string, filePath) {
   const eslint = new ESLint({

--- a/test/lint-js.test.js
+++ b/test/lint-js.test.js
@@ -4,16 +4,33 @@ import {assertError, runEslint} from './helper/utils.js';
 const filePath = 'test/helper/js-placeholder.js';
 
 test('success', async () => {
-  const errors = await runEslint('const x = true;\n\nif (x) {\n  // Not empty\n}\n', filePath);
+  const errors = await runEslint(
+    'const x = true;\n\nif (x) {\n  // Not empty\n}\n',
+    filePath,
+  );
   expect(errors).toEqual([]);
 });
 
 test('throw error no-console', async () => {
-  const errors = await runEslint('const x = true;\n\nif (x) {\n  console.log();\n}\n', filePath);
+  const errors = await runEslint(
+    'const x = true;\n\nif (x) {\n  console.log();\n}\n',
+    filePath,
+  );
   assertError(errors, ['no-console']);
 });
 
 test('throw error camelcase', async () => {
-  const errors = await runEslint('const not_in_camelcase = true;\n\nif (not_in_camelcase) {\n  // not empty\n}\n', filePath);
+  const errors = await runEslint(
+    'const not_in_camelcase = true;\n\nif (not_in_camelcase) {\n  // not empty\n}\n',
+    filePath,
+  );
   assertError(errors, ['camelcase', 'camelcase']);
+});
+
+test('throw error prettier/prettier', async () => {
+  const errors = await runEslint(
+    "const x = 'a'\n\nif (x) {\n  // not empty\n}\n",
+    filePath,
+  );
+  assertError(errors, ['prettier/prettier']);
 });

--- a/test/lint-json.test.js
+++ b/test/lint-json.test.js
@@ -1,0 +1,26 @@
+import {expect, test} from 'vitest';
+import {assertError, runEslint} from './helper/utils.js';
+
+test('success', async () => {
+  const errors = await runEslint(
+    '{\n  "a": 1\n}\n',
+    'test/helper/placeholder.json',
+  );
+  expect(errors).toEqual([]);
+});
+
+test('throw error json/no-duplicate-keys', async () => {
+  const errors = await runEslint(
+    '{\n  "a": 1,\n  "a": 2\n}\n',
+    'test/helper/placeholder.json',
+  );
+  assertError(errors, ['json/no-duplicate-keys']);
+});
+
+test('allow trailing commas in tsconfig.json (jsonc)', async () => {
+  const errors = await runEslint(
+    '{\n  "compilerOptions": {},\n}\n',
+    'tsconfig.json',
+  );
+  expect(errors).toEqual([]);
+});

--- a/test/lint-markdown.test.js
+++ b/test/lint-markdown.test.js
@@ -1,0 +1,14 @@
+import {expect, test} from 'vitest';
+import {assertError, runEslint} from './helper/utils.js';
+
+const filePath = 'test/helper/placeholder.md';
+
+test('success', async () => {
+  const errors = await runEslint('# Title\n\nSome text.\n', filePath);
+  expect(errors).toEqual([]);
+});
+
+test('throw error markdown/fenced-code-language', async () => {
+  const errors = await runEslint('```\ncode\n```\n', filePath);
+  assertError(errors, ['markdown/fenced-code-language']);
+});

--- a/test/lint-ts.test.js
+++ b/test/lint-ts.test.js
@@ -4,17 +4,26 @@ import {assertError, runEslint} from './helper/utils.js';
 const filePath = 'test/helper/ts-placeholder.ts';
 
 test('success', async () => {
-  const errors = await runEslint('type OneType = string; const t: OneType = \'randomString\';\n', filePath);
+  const errors = await runEslint(
+    "type OneType = string;\nconst t: OneType = 'randomString';\n",
+    filePath,
+  );
   expect(errors).toEqual([]);
 });
 
 test('throw error no-console', async () => {
-  const errors = await runEslint('const x = true;\n\nif (x) {\n  console.log();\n}\n', filePath);
+  const errors = await runEslint(
+    'const x = true;\n\nif (x) {\n  console.log();\n}\n',
+    filePath,
+  );
   assertError(errors, ['no-console']);
 });
 
 test('throw error naming-convention', async () => {
-  const errors = await runEslint('const not_in_camelcase = true;\n\nif (not_in_camelcase) {\n  // not empty\n}\n', filePath);
+  const errors = await runEslint(
+    'const not_in_camelcase = true;\n\nif (not_in_camelcase) {\n  // not empty\n}\n',
+    filePath,
+  );
   assertError(errors, ['@typescript-eslint/naming-convention']);
 });
 
@@ -24,6 +33,9 @@ test('throw error no-inferrable-types', async () => {
 });
 
 test('throw error import-x/extensions on a .js relative import', async () => {
-  const errors = await runEslint('import foo from \'./bar.js\';\n\nif (foo) {\n  // not empty\n}\n', filePath);
+  const errors = await runEslint(
+    "import foo from './bar.js';\n\nvoid foo;\n",
+    filePath,
+  );
   assertError(errors, ['import-x/extensions']);
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,7 +2,7 @@ import {expect, test} from 'vitest';
 import {findRule} from '../source/utils.js';
 /** @import { Linter } from 'eslint' */
 
-test('Finds the rule by it\'s name', () => {
+test("Finds the rule by it's name", () => {
   /** @type {Linter.Config[]} */
   const config = [
     {rules: {rule1: ['off', 'rule1']}},


### PR DESCRIPTION
## Résumé

Monte `eslint-config-xo` de 0.51.0 à 0.53.2, qui intègre nativement le support de Prettier, du Markdown et du JSON. L'intégration se fait via la nouvelle option `prettier: true` de xo, sans brancher de plugins à la main.

La config couvre désormais :
- **Prettier** : formatage du code via la règle `prettier/prettier` (appliqué par `eslint --fix`). `prettier` est fourni en `dependencies`, aucun install supplémentaire côté projets consommateurs.
- **Markdown** : lint des fichiers `.md` en GitHub-Flavored Markdown (`@eslint/markdown`).
- **JSON** : validation des fichiers JSON/JSONC/JSON5 (`@eslint/json`), trailing commas autorisées sur `tsconfig.json`. Le filtre qui désactivait le JSON (bug xojs/xo#798, désormais résolu) est supprimé.

## Détails

- `eslint-config-xo` `^0.51.0` → `^0.53.2`
- `prettier` `^3.8.4` ajouté en `dependencies` (peerDep de xo)
- `typescript` `^5.9.3` → `^6.0.3` pour satisfaire la peerDep de xo (`>=6`)
- `source/config.js` : `eslintConfigXo({space: 2, prettier: true})`, suppression du filtre JSON et de l'override `@stylistic/object-curly-newline` (géré par Prettier)
- Tests portés sur Vitest, fixtures adaptées aux nouvelles règles, et nouveaux tests pour JSON, Markdown et Prettier

## Vérifications

- `eslint .` : 0 erreur
- `npm run build-check` (tsc, TypeScript 6.0.3) : OK
- `npm test` (Vitest) : 16 tests passent