### PR TITLE
chore: require Node.js 24 instead of 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 22
+          - 24
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://www.radiofrance.fr"
   },
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=24.0.0"
   },
   "type": "module",
   "main": "source/config.js",


### PR DESCRIPTION
## Contexte

Mise à jour du prérequis Node.js de la version 22 vers la version 24.

## Changements

- `package.json` : `engines.node` passe de `>=22.12.0` à `>=24.0.0`
- `.github/workflows/main.yml` : la matrice CI cible désormais Node.js `24`

`@types/node` était déjà en `^24.7.0`, donc cohérent.

https://claude.ai/code/session_01BMHmjRwiYpzJqcGe6qBfKt